### PR TITLE
ZIOS-11451: Add legal hold status field to messages

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "wireapp/generic-message-proto" "v1.23.0"
+github "wireapp/generic-message-proto" "fix/reaction-legal-hold"
 github "wireapp/backend-api-protobuf" "2.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "wireapp/swift-protobuf" "1.5.0"
 github "wireapp/backend-api-protobuf" "2.2"
-github "wireapp/generic-message-proto" "v1.23.0"
+github "wireapp/generic-message-proto" "13024746cb96527b5c3d7121e8d582a8b37e02c7"
 github "wireapp/protobuf-objc" "1.9.14"
+github "wireapp/swift-protobuf" "1.5.0"

--- a/Protos/messages.pb.swift
+++ b/Protos/messages.pb.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2018 Wire Swiss GmbH
+// Copyright (C) 2019 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -97,6 +97,40 @@ public enum EncryptionAlgorithm: SwiftProtobuf.Enum {
 #if swift(>=4.2)
 
 extension EncryptionAlgorithm: CaseIterable {
+  // Support synthesized by the compiler.
+}
+
+#endif  // swift(>=4.2)
+
+public enum LegalHoldStatus: SwiftProtobuf.Enum {
+  public typealias RawValue = Int
+  case disabled // = 0
+  case enabled // = 1
+
+  public init() {
+    self = .disabled
+  }
+
+  public init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .disabled
+    case 1: self = .enabled
+    default: return nil
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .disabled: return 0
+    case .enabled: return 1
+    }
+  }
+
+}
+
+#if swift(>=4.2)
+
+extension LegalHoldStatus: CaseIterable {
   // Support synthesized by the compiler.
 }
 
@@ -507,6 +541,16 @@ public struct Text {
   /// Clears the value of `expectsReadConfirmation`. Subsequent reads from it will return its default value.
   public mutating func clearExpectsReadConfirmation() {_uniqueStorage()._expectsReadConfirmation = nil}
 
+  /// whether this message was sent to legal hold
+  public var legalHoldStatus: LegalHoldStatus {
+    get {return _storage._legalHoldStatus ?? .disabled}
+    set {_uniqueStorage()._legalHoldStatus = newValue}
+  }
+  /// Returns true if `legalHoldStatus` has been explicitly set.
+  public var hasLegalHoldStatus: Bool {return _storage._legalHoldStatus != nil}
+  /// Clears the value of `legalHoldStatus`. Subsequent reads from it will return its default value.
+  public mutating func clearLegalHoldStatus() {_uniqueStorage()._legalHoldStatus = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -538,12 +582,23 @@ public struct Knock {
   /// Clears the value of `expectsReadConfirmation`. Subsequent reads from it will return its default value.
   public mutating func clearExpectsReadConfirmation() {self._expectsReadConfirmation = nil}
 
+  /// whether this message was sent to legal hold
+  public var legalHoldStatus: LegalHoldStatus {
+    get {return _legalHoldStatus ?? .disabled}
+    set {_legalHoldStatus = newValue}
+  }
+  /// Returns true if `legalHoldStatus` has been explicitly set.
+  public var hasLegalHoldStatus: Bool {return self._legalHoldStatus != nil}
+  /// Clears the value of `legalHoldStatus`. Subsequent reads from it will return its default value.
+  public mutating func clearLegalHoldStatus() {self._legalHoldStatus = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
   fileprivate var _hotKnock: Bool? = nil
   fileprivate var _expectsReadConfirmation: Bool? = nil
+  fileprivate var _legalHoldStatus: LegalHoldStatus? = nil
 }
 
 public struct LinkPreview {
@@ -1112,6 +1167,16 @@ public struct Location {
   /// Clears the value of `expectsReadConfirmation`. Subsequent reads from it will return its default value.
   public mutating func clearExpectsReadConfirmation() {self._expectsReadConfirmation = nil}
 
+  /// whether this message was sent to legal hold
+  public var legalHoldStatus: LegalHoldStatus {
+    get {return _legalHoldStatus ?? .disabled}
+    set {_legalHoldStatus = newValue}
+  }
+  /// Returns true if `legalHoldStatus` has been explicitly set.
+  public var hasLegalHoldStatus: Bool {return self._legalHoldStatus != nil}
+  /// Clears the value of `legalHoldStatus`. Subsequent reads from it will return its default value.
+  public mutating func clearLegalHoldStatus() {self._legalHoldStatus = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -1121,6 +1186,7 @@ public struct Location {
   fileprivate var _name: String? = nil
   fileprivate var _zoom: Int32? = nil
   fileprivate var _expectsReadConfirmation: Bool? = nil
+  fileprivate var _legalHoldStatus: LegalHoldStatus? = nil
 }
 
 /// deprecated in favour of Asset.Original.ImageMetaData
@@ -1262,7 +1328,7 @@ public struct Asset {
   /// Clears the value of `original`. Subsequent reads from it will return its default value.
   public mutating func clearOriginal() {_uniqueStorage()._original = nil}
 
-  ///  optional Preview preview = 2;  // deprecated - preview was completely replaced
+  /// optional Preview preview = 2;  // deprecated - preview was completely replaced
   public var status: OneOf_Status? {
     get {return _storage._status}
     set {_uniqueStorage()._status = newValue}
@@ -1303,9 +1369,19 @@ public struct Asset {
   /// Clears the value of `expectsReadConfirmation`. Subsequent reads from it will return its default value.
   public mutating func clearExpectsReadConfirmation() {_uniqueStorage()._expectsReadConfirmation = nil}
 
+  /// whether this message was sent to legal hold
+  public var legalHoldStatus: LegalHoldStatus {
+    get {return _storage._legalHoldStatus ?? .disabled}
+    set {_uniqueStorage()._legalHoldStatus = newValue}
+  }
+  /// Returns true if `legalHoldStatus` has been explicitly set.
+  public var hasLegalHoldStatus: Bool {return _storage._legalHoldStatus != nil}
+  /// Clears the value of `legalHoldStatus`. Subsequent reads from it will return its default value.
+  public mutating func clearLegalHoldStatus() {_uniqueStorage()._legalHoldStatus = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///  optional Preview preview = 2;  // deprecated - preview was completely replaced
+  /// optional Preview preview = 2;  // deprecated - preview was completely replaced
   public enum OneOf_Status: Equatable {
     case notUploaded(Asset.NotUploaded)
     case uploaded(Asset.RemoteData)
@@ -1663,7 +1739,7 @@ public struct Asset {
     /// Clears the value of `assetID`. Subsequent reads from it will return its default value.
     public mutating func clearAssetID() {self._assetID = nil}
 
-    ///    optional bytes asset_token = 4; // deprecated - changed type to string
+    /// optional bytes asset_token = 4; // deprecated - changed type to string
     public var assetToken: String {
       get {return _assetToken ?? String()}
       set {_assetToken = newValue}
@@ -1773,12 +1849,23 @@ public struct Reaction {
   /// Clears the value of `messageID`. Subsequent reads from it will return its default value.
   public mutating func clearMessageID() {self._messageID = nil}
 
+  /// whether this message was sent to legal hold
+  public var legalHoldStatus: LegalHoldStatus {
+    get {return _legalHoldStatus ?? .disabled}
+    set {_legalHoldStatus = newValue}
+  }
+  /// Returns true if `legalHoldStatus` has been explicitly set.
+  public var hasLegalHoldStatus: Bool {return self._legalHoldStatus != nil}
+  /// Clears the value of `legalHoldStatus`. Subsequent reads from it will return its default value.
+  public mutating func clearLegalHoldStatus() {self._legalHoldStatus = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
   fileprivate var _emoji: String? = nil
   fileprivate var _messageID: String? = nil
+  fileprivate var _legalHoldStatus: LegalHoldStatus? = nil
 }
 
 public struct Calling {
@@ -1814,6 +1901,13 @@ extension EncryptionAlgorithm: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "AES_CBC"),
     1: .same(proto: "AES_GCM"),
+  ]
+}
+
+extension LegalHoldStatus: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "DISABLED"),
+    1: .same(proto: "ENABLED"),
   ]
 }
 
@@ -2282,6 +2376,7 @@ extension Text: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase,
     4: .same(proto: "mentions"),
     5: .same(proto: "quote"),
     6: .standard(proto: "expects_read_confirmation"),
+    7: .standard(proto: "legal_hold_status"),
   ]
 
   fileprivate class _StorageClass {
@@ -2290,6 +2385,7 @@ extension Text: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase,
     var _mentions: [Mention] = []
     var _quote: Quote? = nil
     var _expectsReadConfirmation: Bool? = nil
+    var _legalHoldStatus: LegalHoldStatus? = nil
 
     static let defaultInstance = _StorageClass()
 
@@ -2301,6 +2397,7 @@ extension Text: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase,
       _mentions = source._mentions
       _quote = source._quote
       _expectsReadConfirmation = source._expectsReadConfirmation
+      _legalHoldStatus = source._legalHoldStatus
     }
   }
 
@@ -2331,6 +2428,7 @@ extension Text: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase,
         case 4: try decoder.decodeRepeatedMessageField(value: &_storage._mentions)
         case 5: try decoder.decodeSingularMessageField(value: &_storage._quote)
         case 6: try decoder.decodeSingularBoolField(value: &_storage._expectsReadConfirmation)
+        case 7: try decoder.decodeSingularEnumField(value: &_storage._legalHoldStatus)
         default: break
         }
       }
@@ -2354,6 +2452,9 @@ extension Text: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase,
       if let v = _storage._expectsReadConfirmation {
         try visitor.visitSingularBoolField(value: v, fieldNumber: 6)
       }
+      if let v = _storage._legalHoldStatus {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 7)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -2368,6 +2469,7 @@ extension Text: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase,
         if _storage._mentions != rhs_storage._mentions {return false}
         if _storage._quote != rhs_storage._quote {return false}
         if _storage._expectsReadConfirmation != rhs_storage._expectsReadConfirmation {return false}
+        if _storage._legalHoldStatus != rhs_storage._legalHoldStatus {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -2382,6 +2484,7 @@ extension Knock: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "hot_knock"),
     2: .standard(proto: "expects_read_confirmation"),
+    3: .standard(proto: "legal_hold_status"),
   ]
 
   public var isInitialized: Bool {
@@ -2394,6 +2497,7 @@ extension Knock: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase
       switch fieldNumber {
       case 1: try decoder.decodeSingularBoolField(value: &self._hotKnock)
       case 2: try decoder.decodeSingularBoolField(value: &self._expectsReadConfirmation)
+      case 3: try decoder.decodeSingularEnumField(value: &self._legalHoldStatus)
       default: break
       }
     }
@@ -2406,12 +2510,16 @@ extension Knock: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase
     if let v = self._expectsReadConfirmation {
       try visitor.visitSingularBoolField(value: v, fieldNumber: 2)
     }
+    if let v = self._legalHoldStatus {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Knock, rhs: Knock) -> Bool {
     if lhs._hotKnock != rhs._hotKnock {return false}
     if lhs._expectsReadConfirmation != rhs._expectsReadConfirmation {return false}
+    if lhs._legalHoldStatus != rhs._legalHoldStatus {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3080,6 +3188,7 @@ extension Location: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
     3: .same(proto: "name"),
     4: .same(proto: "zoom"),
     5: .standard(proto: "expects_read_confirmation"),
+    6: .standard(proto: "legal_hold_status"),
   ]
 
   public var isInitialized: Bool {
@@ -3096,6 +3205,7 @@ extension Location: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
       case 3: try decoder.decodeSingularStringField(value: &self._name)
       case 4: try decoder.decodeSingularInt32Field(value: &self._zoom)
       case 5: try decoder.decodeSingularBoolField(value: &self._expectsReadConfirmation)
+      case 6: try decoder.decodeSingularEnumField(value: &self._legalHoldStatus)
       default: break
       }
     }
@@ -3117,6 +3227,9 @@ extension Location: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
     if let v = self._expectsReadConfirmation {
       try visitor.visitSingularBoolField(value: v, fieldNumber: 5)
     }
+    if let v = self._legalHoldStatus {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -3126,6 +3239,7 @@ extension Location: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
     if lhs._name != rhs._name {return false}
     if lhs._zoom != rhs._zoom {return false}
     if lhs._expectsReadConfirmation != rhs._expectsReadConfirmation {return false}
+    if lhs._legalHoldStatus != rhs._legalHoldStatus {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3239,6 +3353,7 @@ extension Asset: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase
     4: .same(proto: "uploaded"),
     5: .same(proto: "preview"),
     6: .standard(proto: "expects_read_confirmation"),
+    7: .standard(proto: "legal_hold_status"),
   ]
 
   fileprivate class _StorageClass {
@@ -3246,6 +3361,7 @@ extension Asset: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase
     var _status: Asset.OneOf_Status?
     var _preview: Asset.Preview? = nil
     var _expectsReadConfirmation: Bool? = nil
+    var _legalHoldStatus: LegalHoldStatus? = nil
 
     static let defaultInstance = _StorageClass()
 
@@ -3256,6 +3372,7 @@ extension Asset: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase
       _status = source._status
       _preview = source._preview
       _expectsReadConfirmation = source._expectsReadConfirmation
+      _legalHoldStatus = source._legalHoldStatus
     }
   }
 
@@ -3296,6 +3413,7 @@ extension Asset: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase
           if let v = v {_storage._status = .uploaded(v)}
         case 5: try decoder.decodeSingularMessageField(value: &_storage._preview)
         case 6: try decoder.decodeSingularBoolField(value: &_storage._expectsReadConfirmation)
+        case 7: try decoder.decodeSingularEnumField(value: &_storage._legalHoldStatus)
         default: break
         }
       }
@@ -3320,6 +3438,9 @@ extension Asset: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase
       if let v = _storage._expectsReadConfirmation {
         try visitor.visitSingularBoolField(value: v, fieldNumber: 6)
       }
+      if let v = _storage._legalHoldStatus {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 7)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -3333,6 +3454,7 @@ extension Asset: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase
         if _storage._status != rhs_storage._status {return false}
         if _storage._preview != rhs_storage._preview {return false}
         if _storage._expectsReadConfirmation != rhs_storage._expectsReadConfirmation {return false}
+        if _storage._legalHoldStatus != rhs_storage._legalHoldStatus {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -3825,6 +3947,7 @@ extension Reaction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "emoji"),
     2: .standard(proto: "message_id"),
+    3: .standard(proto: "legal_hold_status"),
   ]
 
   public var isInitialized: Bool {
@@ -3837,6 +3960,7 @@ extension Reaction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
       switch fieldNumber {
       case 1: try decoder.decodeSingularStringField(value: &self._emoji)
       case 2: try decoder.decodeSingularStringField(value: &self._messageID)
+      case 3: try decoder.decodeSingularEnumField(value: &self._legalHoldStatus)
       default: break
       }
     }
@@ -3849,12 +3973,16 @@ extension Reaction: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
     if let v = self._messageID {
       try visitor.visitSingularStringField(value: v, fieldNumber: 2)
     }
+    if let v = self._legalHoldStatus {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Reaction, rhs: Reaction) -> Bool {
     if lhs._emoji != rhs._emoji {return false}
     if lhs._messageID != rhs._messageID {return false}
+    if lhs._legalHoldStatus != rhs._legalHoldStatus {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Protos/otr.pb.swift
+++ b/Protos/otr.pb.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2018 Wire Swiss GmbH
+// Copyright (C) 2019 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## What's new in this PR?

### Issues

We want to include a `legalHoldStatus` in the messages sent by the user.

### Solutions

Update the message protobuf version.

## Dependencies

Needs releases with:

- [ ] https://github.com/wireapp/generic-message-proto/pull/47

### Notes

We also need to update the definition for Obj-C files.