### PR TITLE
Update protobuf version to v1.24.2

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "wireapp/generic-message-proto" "v1.24.1"
+github "wireapp/generic-message-proto" "v1.24.2"
 github "wireapp/backend-api-protobuf" "2.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "wireapp/backend-api-protobuf" "2.2"
-github "wireapp/generic-message-proto" "v1.24.1"
+github "wireapp/generic-message-proto" "v1.24.2"
 github "wireapp/protobuf-objc" "1.9.14"
 github "wireapp/swift-protobuf" "1.5.0"

--- a/Protos/Messages.pb.h
+++ b/Protos/Messages.pb.h
@@ -138,8 +138,9 @@ BOOL ZMEncryptionAlgorithmIsValidValue(ZMEncryptionAlgorithm value);
 NSString *NSStringFromZMEncryptionAlgorithm(ZMEncryptionAlgorithm value);
 
 typedef NS_ENUM(SInt32, ZMLegalHoldStatus) {
-  ZMLegalHoldStatusDISABLED = 0,
-  ZMLegalHoldStatusENABLED = 1,
+  ZMLegalHoldStatusUNKNOWN = 0,
+  ZMLegalHoldStatusDISABLED = 1,
+  ZMLegalHoldStatusENABLED = 2,
 };
 
 BOOL ZMLegalHoldStatusIsValidValue(ZMLegalHoldStatus value);

--- a/Protos/Messages.pb.m
+++ b/Protos/Messages.pb.m
@@ -76,6 +76,7 @@ NSString *NSStringFromZMEncryptionAlgorithm(ZMEncryptionAlgorithm value) {
 
 BOOL ZMLegalHoldStatusIsValidValue(ZMLegalHoldStatus value) {
   switch (value) {
+    case ZMLegalHoldStatusUNKNOWN:
     case ZMLegalHoldStatusDISABLED:
     case ZMLegalHoldStatusENABLED:
       return YES;
@@ -85,6 +86,8 @@ BOOL ZMLegalHoldStatusIsValidValue(ZMLegalHoldStatus value) {
 }
 NSString *NSStringFromZMLegalHoldStatus(ZMLegalHoldStatus value) {
   switch (value) {
+    case ZMLegalHoldStatusUNKNOWN:
+      return @"ZMLegalHoldStatusUNKNOWN";
     case ZMLegalHoldStatusDISABLED:
       return @"ZMLegalHoldStatusDISABLED";
     case ZMLegalHoldStatusENABLED:
@@ -2497,7 +2500,7 @@ static ZMEphemeral* defaultZMEphemeralInstance = nil;
     self.content = @"";
     self.quote = [ZMQuote defaultInstance];
     self.expectsReadConfirmation = NO;
-    self.legalHoldStatus = ZMLegalHoldStatusDISABLED;
+    self.legalHoldStatus = ZMLegalHoldStatusUNKNOWN;
   }
   return self;
 }
@@ -2978,7 +2981,7 @@ static ZMText* defaultZMTextInstance = nil;
 }
 - (ZMTextBuilder*) clearLegalHoldStatus {
   resultText.hasLegalHoldStatus = NO;
-  resultText.legalHoldStatus = ZMLegalHoldStatusDISABLED;
+  resultText.legalHoldStatus = ZMLegalHoldStatusUNKNOWN;
   return self;
 }
 @end
@@ -3026,7 +3029,7 @@ static ZMText* defaultZMTextInstance = nil;
   if ((self = [super init])) {
     self.hotKnock = NO;
     self.expectsReadConfirmation = NO;
-    self.legalHoldStatus = ZMLegalHoldStatusDISABLED;
+    self.legalHoldStatus = ZMLegalHoldStatusUNKNOWN;
   }
   return self;
 }
@@ -3300,7 +3303,7 @@ static ZMKnock* defaultZMKnockInstance = nil;
 }
 - (ZMKnockBuilder*) clearLegalHoldStatus {
   resultKnock.hasLegalHoldStatus = NO;
-  resultKnock.legalHoldStatus = ZMLegalHoldStatusDISABLED;
+  resultKnock.legalHoldStatus = ZMLegalHoldStatusUNKNOWN;
   return self;
 }
 @end
@@ -6841,7 +6844,7 @@ NSString *NSStringFromZMConfirmationType(ZMConfirmationType value) {
     self.name = @"";
     self.zoom = 0;
     self.expectsReadConfirmation = NO;
-    self.legalHoldStatus = ZMLegalHoldStatusDISABLED;
+    self.legalHoldStatus = ZMLegalHoldStatusUNKNOWN;
   }
   return self;
 }
@@ -7238,7 +7241,7 @@ static ZMLocation* defaultZMLocationInstance = nil;
 }
 - (ZMLocationBuilder*) clearLegalHoldStatus {
   resultLocation.hasLegalHoldStatus = NO;
-  resultLocation.legalHoldStatus = ZMLegalHoldStatusDISABLED;
+  resultLocation.legalHoldStatus = ZMLegalHoldStatusUNKNOWN;
   return self;
 }
 @end
@@ -8025,7 +8028,7 @@ static ZMImageAsset* defaultZMImageAssetInstance = nil;
     self.uploaded = [ZMAssetRemoteData defaultInstance];
     self.preview = [ZMAssetPreview defaultInstance];
     self.expectsReadConfirmation = NO;
-    self.legalHoldStatus = ZMLegalHoldStatusDISABLED;
+    self.legalHoldStatus = ZMLegalHoldStatusUNKNOWN;
   }
   return self;
 }
@@ -10859,7 +10862,7 @@ static ZMAssetRemoteData* defaultZMAssetRemoteDataInstance = nil;
 }
 - (ZMAssetBuilder*) clearLegalHoldStatus {
   resultAsset.hasLegalHoldStatus = NO;
-  resultAsset.legalHoldStatus = ZMLegalHoldStatusDISABLED;
+  resultAsset.legalHoldStatus = ZMLegalHoldStatusUNKNOWN;
   return self;
 }
 @end
@@ -11209,7 +11212,7 @@ static ZMExternal* defaultZMExternalInstance = nil;
   if ((self = [super init])) {
     self.emoji = @"";
     self.messageId = @"";
-    self.legalHoldStatus = ZMLegalHoldStatusDISABLED;
+    self.legalHoldStatus = ZMLegalHoldStatusUNKNOWN;
   }
   return self;
 }
@@ -11483,7 +11486,7 @@ static ZMReaction* defaultZMReactionInstance = nil;
 }
 - (ZMReactionBuilder*) clearLegalHoldStatus {
   resultReaction.hasLegalHoldStatus = NO;
-  resultReaction.legalHoldStatus = ZMLegalHoldStatusDISABLED;
+  resultReaction.legalHoldStatus = ZMLegalHoldStatusUNKNOWN;
   return self;
 }
 @end

--- a/Protos/messages.pb.swift
+++ b/Protos/messages.pb.swift
@@ -104,25 +104,28 @@ extension EncryptionAlgorithm: CaseIterable {
 
 public enum LegalHoldStatus: SwiftProtobuf.Enum {
   public typealias RawValue = Int
-  case disabled // = 0
-  case enabled // = 1
+  case unknown // = 0
+  case disabled // = 1
+  case enabled // = 2
 
   public init() {
-    self = .disabled
+    self = .unknown
   }
 
   public init?(rawValue: Int) {
     switch rawValue {
-    case 0: self = .disabled
-    case 1: self = .enabled
+    case 0: self = .unknown
+    case 1: self = .disabled
+    case 2: self = .enabled
     default: return nil
     }
   }
 
   public var rawValue: Int {
     switch self {
-    case .disabled: return 0
-    case .enabled: return 1
+    case .unknown: return 0
+    case .disabled: return 1
+    case .enabled: return 2
     }
   }
 
@@ -543,7 +546,7 @@ public struct Text {
 
   /// whether this message was sent to legal hold
   public var legalHoldStatus: LegalHoldStatus {
-    get {return _storage._legalHoldStatus ?? .disabled}
+    get {return _storage._legalHoldStatus ?? .unknown}
     set {_uniqueStorage()._legalHoldStatus = newValue}
   }
   /// Returns true if `legalHoldStatus` has been explicitly set.
@@ -584,7 +587,7 @@ public struct Knock {
 
   /// whether this message was sent to legal hold
   public var legalHoldStatus: LegalHoldStatus {
-    get {return _legalHoldStatus ?? .disabled}
+    get {return _legalHoldStatus ?? .unknown}
     set {_legalHoldStatus = newValue}
   }
   /// Returns true if `legalHoldStatus` has been explicitly set.
@@ -1169,7 +1172,7 @@ public struct Location {
 
   /// whether this message was sent to legal hold
   public var legalHoldStatus: LegalHoldStatus {
-    get {return _legalHoldStatus ?? .disabled}
+    get {return _legalHoldStatus ?? .unknown}
     set {_legalHoldStatus = newValue}
   }
   /// Returns true if `legalHoldStatus` has been explicitly set.
@@ -1371,7 +1374,7 @@ public struct Asset {
 
   /// whether this message was sent to legal hold
   public var legalHoldStatus: LegalHoldStatus {
-    get {return _storage._legalHoldStatus ?? .disabled}
+    get {return _storage._legalHoldStatus ?? .unknown}
     set {_uniqueStorage()._legalHoldStatus = newValue}
   }
   /// Returns true if `legalHoldStatus` has been explicitly set.
@@ -1851,7 +1854,7 @@ public struct Reaction {
 
   /// whether this message was sent to legal hold
   public var legalHoldStatus: LegalHoldStatus {
-    get {return _legalHoldStatus ?? .disabled}
+    get {return _legalHoldStatus ?? .unknown}
     set {_legalHoldStatus = newValue}
   }
   /// Returns true if `legalHoldStatus` has been explicitly set.
@@ -1906,8 +1909,9 @@ extension EncryptionAlgorithm: SwiftProtobuf._ProtoNameProviding {
 
 extension LegalHoldStatus: SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "DISABLED"),
-    1: .same(proto: "ENABLED"),
+    0: .same(proto: "UNKNOWN"),
+    1: .same(proto: "DISABLED"),
+    2: .same(proto: "ENABLED"),
   ]
 }
 


### PR DESCRIPTION
## What's new in this PR?

Update to the generic-message protobuf to `v.1.24.2` which add a default `.unknown` case to the `legalHoldStatus`