### PR TITLE
chore: update Azure to Xcode 12

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "wireapp/swift-protobuf" "1.12.0_xcode12"
+github "wireapp/swift-protobuf" "1.13.0_xcode12.2"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "wireapp/swift-protobuf" ~> 1.13.0
+github "wireapp/swift-protobuf" "1.12.0_xcode12"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "wireapp/swift-protobuf" "1.13.0_xcode12.2"
+github "wireapp/swift-protobuf" ~> 1.13.0 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "wireapp/backend-api-protobuf" "2.3"
 github "wireapp/generic-message-proto" "v1.27.1"
-github "wireapp/swift-protobuf" "1.12.0_xcode12"
+github "wireapp/swift-protobuf" "1.13.0_xcode12.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "wireapp/backend-api-protobuf" "2.3"
 github "wireapp/generic-message-proto" "v1.27.1"
-github "wireapp/swift-protobuf" "1.13.0"
+github "wireapp/swift-protobuf" "1.12.0_xcode12"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "wireapp/backend-api-protobuf" "2.3"
 github "wireapp/generic-message-proto" "v1.27.1"
-github "wireapp/swift-protobuf" "1.13.0_xcode12.2"
+github "wireapp/swift-protobuf" "1.13.0"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
   - repository: wire-ios-shared-resources
     type: github
     name: wireapp/wire-ios-shared-resources
-    ref: refs/heads/master # Branch to fetch the jobs template from
+    ref: refs/heads/chore/xcode12 # Branch to fetch the jobs template from
     endpoint: wireapp
 
 trigger:


### PR DESCRIPTION
bump for components

### Notice
Carthage can not build Swift proto buf on Azure, use pre-built framework can solve this issue.