### PR TITLE
[Chore] Update protobuf version to v1.35.0

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,1 @@
-github "wireapp/generic-message-proto" "v1.27.1"
-github "wireapp/backend-api-protobuf" "2.3"
+github "wireapp/generic-message-proto" "v1.35.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,2 @@
-github "wireapp/backend-api-protobuf" "2.3"
-github "wireapp/generic-message-proto" "v1.27.1"
+github "wireapp/generic-message-proto" "v1.35.0"
 github "wireapp/swift-protobuf" "1.15.0_xcode12.4"

--- a/Protos/messages.pb.swift
+++ b/Protos/messages.pb.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2020 Wire Swiss GmbH
+// Copyright (C) 2021 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -24,6 +24,23 @@
 //
 // For information on using the generated types, please see the documentation:
 //   https://github.com/apple/swift-protobuf/
+
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 
 import Foundation
 import SwiftProtobuf
@@ -542,6 +559,68 @@ public struct GenericMessage {
   public init() {}
 
   fileprivate var _messageID: String? = nil
+}
+
+public struct QualifiedUserId {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var id: String {
+    get {return _id ?? String()}
+    set {_id = newValue}
+  }
+  /// Returns true if `id` has been explicitly set.
+  public var hasID: Bool {return self._id != nil}
+  /// Clears the value of `id`. Subsequent reads from it will return its default value.
+  public mutating func clearID() {self._id = nil}
+
+  public var domain: String {
+    get {return _domain ?? String()}
+    set {_domain = newValue}
+  }
+  /// Returns true if `domain` has been explicitly set.
+  public var hasDomain: Bool {return self._domain != nil}
+  /// Clears the value of `domain`. Subsequent reads from it will return its default value.
+  public mutating func clearDomain() {self._domain = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _id: String? = nil
+  fileprivate var _domain: String? = nil
+}
+
+public struct QualifiedConversationId {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var id: String {
+    get {return _id ?? String()}
+    set {_id = newValue}
+  }
+  /// Returns true if `id` has been explicitly set.
+  public var hasID: Bool {return self._id != nil}
+  /// Clears the value of `id`. Subsequent reads from it will return its default value.
+  public mutating func clearID() {self._id = nil}
+
+  public var domain: String {
+    get {return _domain ?? String()}
+    set {_domain = newValue}
+  }
+  /// Returns true if `domain` has been explicitly set.
+  public var hasDomain: Bool {return self._domain != nil}
+  /// Clears the value of `domain`. Subsequent reads from it will return its default value.
+  public mutating func clearDomain() {self._domain = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _id: String? = nil
+  fileprivate var _domain: String? = nil
 }
 
 public struct Composite {
@@ -1278,6 +1357,9 @@ public struct Mention {
 
   public var mentionType: Mention.OneOf_MentionType? = nil
 
+  /// deprecated. Should be set such that old clients always fail when looking
+  /// up the user. Ideally, this should not be a problem, as a non-federation
+  /// aware user should never be part of a federated conversation.
   public var userID: String {
     get {
       if case .userID(let v)? = mentionType {return v}
@@ -1286,9 +1368,22 @@ public struct Mention {
     set {mentionType = .userID(newValue)}
   }
 
+  /// only optional to maintain backwards compatibility.
+  public var qualifiedUserID: QualifiedUserId {
+    get {return _qualifiedUserID ?? QualifiedUserId()}
+    set {_qualifiedUserID = newValue}
+  }
+  /// Returns true if `qualifiedUserID` has been explicitly set.
+  public var hasQualifiedUserID: Bool {return self._qualifiedUserID != nil}
+  /// Clears the value of `qualifiedUserID`. Subsequent reads from it will return its default value.
+  public mutating func clearQualifiedUserID() {self._qualifiedUserID = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public enum OneOf_MentionType: Equatable {
+    /// deprecated. Should be set such that old clients always fail when looking
+    /// up the user. Ideally, this should not be a problem, as a non-federation
+    /// aware user should never be part of a federated conversation.
     case userID(String)
 
   #if !swift(>=4.1)
@@ -1310,6 +1405,7 @@ public struct Mention {
 
   fileprivate var _start: Int32? = nil
   fileprivate var _length: Int32? = nil
+  fileprivate var _qualifiedUserID: QualifiedUserId? = nil
 }
 
 public struct LastRead {
@@ -1317,6 +1413,8 @@ public struct LastRead {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  /// deprecated. Should be set such that old clients always fail when looking up
+  /// the conversation.
   public var conversationID: String {
     get {return _conversationID ?? String()}
     set {_conversationID = newValue}
@@ -1335,12 +1433,23 @@ public struct LastRead {
   /// Clears the value of `lastReadTimestamp`. Subsequent reads from it will return its default value.
   public mutating func clearLastReadTimestamp() {self._lastReadTimestamp = nil}
 
+  /// only optional to maintain backwards compatibility
+  public var qualifiedConversationID: QualifiedConversationId {
+    get {return _qualifiedConversationID ?? QualifiedConversationId()}
+    set {_qualifiedConversationID = newValue}
+  }
+  /// Returns true if `qualifiedConversationID` has been explicitly set.
+  public var hasQualifiedConversationID: Bool {return self._qualifiedConversationID != nil}
+  /// Clears the value of `qualifiedConversationID`. Subsequent reads from it will return its default value.
+  public mutating func clearQualifiedConversationID() {self._qualifiedConversationID = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
   fileprivate var _conversationID: String? = nil
   fileprivate var _lastReadTimestamp: Int64? = nil
+  fileprivate var _qualifiedConversationID: QualifiedConversationId? = nil
 }
 
 public struct Cleared {
@@ -1348,6 +1457,8 @@ public struct Cleared {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  /// deprecated. Should be set such that old clients always fail when looking up
+  /// the conversation.
   public var conversationID: String {
     get {return _conversationID ?? String()}
     set {_conversationID = newValue}
@@ -1366,12 +1477,23 @@ public struct Cleared {
   /// Clears the value of `clearedTimestamp`. Subsequent reads from it will return its default value.
   public mutating func clearClearedTimestamp() {self._clearedTimestamp = nil}
 
+  /// only optional to maintain backwards compatibility
+  public var qualifiedConversationID: QualifiedConversationId {
+    get {return _qualifiedConversationID ?? QualifiedConversationId()}
+    set {_qualifiedConversationID = newValue}
+  }
+  /// Returns true if `qualifiedConversationID` has been explicitly set.
+  public var hasQualifiedConversationID: Bool {return self._qualifiedConversationID != nil}
+  /// Clears the value of `qualifiedConversationID`. Subsequent reads from it will return its default value.
+  public mutating func clearQualifiedConversationID() {self._qualifiedConversationID = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
   fileprivate var _conversationID: String? = nil
   fileprivate var _clearedTimestamp: Int64? = nil
+  fileprivate var _qualifiedConversationID: QualifiedConversationId? = nil
 }
 
 public struct MessageHide {
@@ -1379,6 +1501,8 @@ public struct MessageHide {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
+  /// deprecated. Should be set such that old clients always fail when looking up
+  /// the conversation.
   public var conversationID: String {
     get {return _conversationID ?? String()}
     set {_conversationID = newValue}
@@ -1397,12 +1521,23 @@ public struct MessageHide {
   /// Clears the value of `messageID`. Subsequent reads from it will return its default value.
   public mutating func clearMessageID() {self._messageID = nil}
 
+  /// only optional to maintain backwards compatibility
+  public var qualifiedConversationID: QualifiedConversationId {
+    get {return _qualifiedConversationID ?? QualifiedConversationId()}
+    set {_qualifiedConversationID = newValue}
+  }
+  /// Returns true if `qualifiedConversationID` has been explicitly set.
+  public var hasQualifiedConversationID: Bool {return self._qualifiedConversationID != nil}
+  /// Clears the value of `qualifiedConversationID`. Subsequent reads from it will return its default value.
+  public mutating func clearQualifiedConversationID() {self._qualifiedConversationID = nil}
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
   fileprivate var _conversationID: String? = nil
   fileprivate var _messageID: String? = nil
+  fileprivate var _qualifiedConversationID: QualifiedConversationId? = nil
 }
 
 public struct MessageDelete {
@@ -2823,6 +2958,94 @@ extension GenericMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplement
   }
 }
 
+extension QualifiedUserId: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = "QualifiedUserId"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "id"),
+    2: .same(proto: "domain"),
+  ]
+
+  public var isInitialized: Bool {
+    if self._id == nil {return false}
+    if self._domain == nil {return false}
+    return true
+  }
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self._id) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self._domain) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if let v = self._id {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if let v = self._domain {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: QualifiedUserId, rhs: QualifiedUserId) -> Bool {
+    if lhs._id != rhs._id {return false}
+    if lhs._domain != rhs._domain {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension QualifiedConversationId: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = "QualifiedConversationId"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "id"),
+    2: .same(proto: "domain"),
+  ]
+
+  public var isInitialized: Bool {
+    if self._id == nil {return false}
+    if self._domain == nil {return false}
+    return true
+  }
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self._id) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self._domain) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if let v = self._id {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if let v = self._domain {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: QualifiedConversationId, rhs: QualifiedConversationId) -> Bool {
+    if lhs._id != rhs._id {return false}
+    if lhs._domain != rhs._domain {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
 extension Composite: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = "Composite"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -3547,11 +3770,13 @@ extension Mention: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBa
     1: .same(proto: "start"),
     2: .same(proto: "length"),
     3: .standard(proto: "user_id"),
+    4: .standard(proto: "qualified_user_id"),
   ]
 
   public var isInitialized: Bool {
     if self._start == nil {return false}
     if self._length == nil {return false}
+    if let v = self._qualifiedUserID, !v.isInitialized {return false}
     return true
   }
 
@@ -3569,6 +3794,7 @@ extension Mention: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBa
         try decoder.decodeSingularStringField(value: &v)
         if let v = v {self.mentionType = .userID(v)}
       }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._qualifiedUserID) }()
       default: break
       }
     }
@@ -3584,6 +3810,9 @@ extension Mention: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBa
     if case .userID(let v)? = self.mentionType {
       try visitor.visitSingularStringField(value: v, fieldNumber: 3)
     }
+    if let v = self._qualifiedUserID {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -3591,6 +3820,7 @@ extension Mention: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBa
     if lhs._start != rhs._start {return false}
     if lhs._length != rhs._length {return false}
     if lhs.mentionType != rhs.mentionType {return false}
+    if lhs._qualifiedUserID != rhs._qualifiedUserID {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3601,11 +3831,13 @@ extension LastRead: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "conversation_id"),
     2: .standard(proto: "last_read_timestamp"),
+    3: .standard(proto: "qualified_conversation_id"),
   ]
 
   public var isInitialized: Bool {
     if self._conversationID == nil {return false}
     if self._lastReadTimestamp == nil {return false}
+    if let v = self._qualifiedConversationID, !v.isInitialized {return false}
     return true
   }
 
@@ -3617,6 +3849,7 @@ extension LastRead: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self._conversationID) }()
       case 2: try { try decoder.decodeSingularInt64Field(value: &self._lastReadTimestamp) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._qualifiedConversationID) }()
       default: break
       }
     }
@@ -3629,12 +3862,16 @@ extension LastRead: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
     if let v = self._lastReadTimestamp {
       try visitor.visitSingularInt64Field(value: v, fieldNumber: 2)
     }
+    if let v = self._qualifiedConversationID {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: LastRead, rhs: LastRead) -> Bool {
     if lhs._conversationID != rhs._conversationID {return false}
     if lhs._lastReadTimestamp != rhs._lastReadTimestamp {return false}
+    if lhs._qualifiedConversationID != rhs._qualifiedConversationID {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3645,11 +3882,13 @@ extension Cleared: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBa
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "conversation_id"),
     2: .standard(proto: "cleared_timestamp"),
+    3: .standard(proto: "qualified_conversation_id"),
   ]
 
   public var isInitialized: Bool {
     if self._conversationID == nil {return false}
     if self._clearedTimestamp == nil {return false}
+    if let v = self._qualifiedConversationID, !v.isInitialized {return false}
     return true
   }
 
@@ -3661,6 +3900,7 @@ extension Cleared: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBa
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self._conversationID) }()
       case 2: try { try decoder.decodeSingularInt64Field(value: &self._clearedTimestamp) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._qualifiedConversationID) }()
       default: break
       }
     }
@@ -3673,12 +3913,16 @@ extension Cleared: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBa
     if let v = self._clearedTimestamp {
       try visitor.visitSingularInt64Field(value: v, fieldNumber: 2)
     }
+    if let v = self._qualifiedConversationID {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Cleared, rhs: Cleared) -> Bool {
     if lhs._conversationID != rhs._conversationID {return false}
     if lhs._clearedTimestamp != rhs._clearedTimestamp {return false}
+    if lhs._qualifiedConversationID != rhs._qualifiedConversationID {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -3689,11 +3933,13 @@ extension MessageHide: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementati
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "conversation_id"),
     2: .standard(proto: "message_id"),
+    3: .standard(proto: "qualified_conversation_id"),
   ]
 
   public var isInitialized: Bool {
     if self._conversationID == nil {return false}
     if self._messageID == nil {return false}
+    if let v = self._qualifiedConversationID, !v.isInitialized {return false}
     return true
   }
 
@@ -3705,6 +3951,7 @@ extension MessageHide: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementati
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self._conversationID) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self._messageID) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._qualifiedConversationID) }()
       default: break
       }
     }
@@ -3717,12 +3964,16 @@ extension MessageHide: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementati
     if let v = self._messageID {
       try visitor.visitSingularStringField(value: v, fieldNumber: 2)
     }
+    if let v = self._qualifiedConversationID {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: MessageHide, rhs: MessageHide) -> Bool {
     if lhs._conversationID != rhs._conversationID {return false}
     if lhs._messageID != rhs._messageID {return false}
+    if lhs._qualifiedConversationID != rhs._qualifiedConversationID {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Protos/otr.pb.swift
+++ b/Protos/otr.pb.swift
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2020 Wire Swiss GmbH
+// Copyright (C) 2021 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -25,6 +25,23 @@
 // For information on using the generated types, please see the documentation:
 //   https://github.com/apple/swift-protobuf/
 
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+
 import Foundation
 import SwiftProtobuf
 
@@ -38,7 +55,43 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
-public struct UserId {
+public enum Proteus_Priority: SwiftProtobuf.Enum {
+  public typealias RawValue = Int
+
+  /// 0 is reserved for errors
+  case lowPriority // = 1
+  case highPriority // = 2
+
+  public init() {
+    self = .lowPriority
+  }
+
+  public init?(rawValue: Int) {
+    switch rawValue {
+    case 1: self = .lowPriority
+    case 2: self = .highPriority
+    default: return nil
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .lowPriority: return 1
+    case .highPriority: return 2
+    }
+  }
+
+}
+
+#if swift(>=4.2)
+
+extension Proteus_Priority: CaseIterable {
+  // Support synthesized by the compiler.
+}
+
+#endif  // swift(>=4.2)
+
+public struct Proteus_UserId {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -59,7 +112,38 @@ public struct UserId {
   fileprivate var _uuid: Data? = nil
 }
 
-public struct ClientId {
+public struct Proteus_QualifiedUserId {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var id: String {
+    get {return _id ?? String()}
+    set {_id = newValue}
+  }
+  /// Returns true if `id` has been explicitly set.
+  public var hasID: Bool {return self._id != nil}
+  /// Clears the value of `id`. Subsequent reads from it will return its default value.
+  public mutating func clearID() {self._id = nil}
+
+  public var domain: String {
+    get {return _domain ?? String()}
+    set {_domain = newValue}
+  }
+  /// Returns true if `domain` has been explicitly set.
+  public var hasDomain: Bool {return self._domain != nil}
+  /// Clears the value of `domain`. Subsequent reads from it will return its default value.
+  public mutating func clearDomain() {self._domain = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _id: String? = nil
+  fileprivate var _domain: String? = nil
+}
+
+public struct Proteus_ClientId {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -80,13 +164,13 @@ public struct ClientId {
   fileprivate var _client: UInt64? = nil
 }
 
-public struct ClientEntry {
+public struct Proteus_ClientEntry {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var client: ClientId {
-    get {return _client ?? ClientId()}
+  public var client: Proteus_ClientId {
+    get {return _client ?? Proteus_ClientId()}
     set {_client = newValue}
   }
   /// Returns true if `client` has been explicitly set.
@@ -107,17 +191,17 @@ public struct ClientEntry {
 
   public init() {}
 
-  fileprivate var _client: ClientId? = nil
+  fileprivate var _client: Proteus_ClientId? = nil
   fileprivate var _text: Data? = nil
 }
 
-public struct UserEntry {
+public struct Proteus_UserEntry {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var user: UserId {
-    get {return _user ?? UserId()}
+  public var user: Proteus_UserId {
+    get {return _user ?? Proteus_UserId()}
     set {_user = newValue}
   }
   /// Returns true if `user` has been explicitly set.
@@ -125,22 +209,46 @@ public struct UserEntry {
   /// Clears the value of `user`. Subsequent reads from it will return its default value.
   public mutating func clearUser() {self._user = nil}
 
-  public var clients: [ClientEntry] = []
+  public var clients: [Proteus_ClientEntry] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _user: UserId? = nil
+  fileprivate var _user: Proteus_UserId? = nil
 }
 
-public struct NewOtrMessage {
+public struct Proteus_QualifiedUserEntry {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var sender: ClientId {
-    get {return _sender ?? ClientId()}
+  public var domain: String {
+    get {return _domain ?? String()}
+    set {_domain = newValue}
+  }
+  /// Returns true if `domain` has been explicitly set.
+  public var hasDomain: Bool {return self._domain != nil}
+  /// Clears the value of `domain`. Subsequent reads from it will return its default value.
+  public mutating func clearDomain() {self._domain = nil}
+
+  public var entries: [Proteus_UserEntry] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _domain: String? = nil
+}
+
+/// deprecated, use QualifiedNewOtrMessage
+public struct Proteus_NewOtrMessage {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var sender: Proteus_ClientId {
+    get {return _sender ?? Proteus_ClientId()}
     set {_sender = newValue}
   }
   /// Returns true if `sender` has been explicitly set.
@@ -148,7 +256,7 @@ public struct NewOtrMessage {
   /// Clears the value of `sender`. Subsequent reads from it will return its default value.
   public mutating func clearSender() {self._sender = nil}
 
-  public var recipients: [UserEntry] = []
+  public var recipients: [Proteus_UserEntry] = []
 
   public var nativePush: Bool {
     get {return _nativePush ?? true}
@@ -168,7 +276,7 @@ public struct NewOtrMessage {
   /// Clears the value of `blob`. Subsequent reads from it will return its default value.
   public mutating func clearBlob() {self._blob = nil}
 
-  public var nativePriority: NewOtrMessage.Priority {
+  public var nativePriority: Proteus_Priority {
     get {return _nativePriority ?? .lowPriority}
     set {_nativePriority = newValue}
   }
@@ -186,62 +294,26 @@ public struct NewOtrMessage {
   /// Clears the value of `transient`. Subsequent reads from it will return its default value.
   public mutating func clearTransient() {self._transient = nil}
 
-  public var reportMissing: [UserId] = []
+  public var reportMissing: [Proteus_UserId] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum Priority: SwiftProtobuf.Enum {
-    public typealias RawValue = Int
-
-    /// 0 is reserved for errors
-    case lowPriority // = 1
-    case highPriority // = 2
-
-    public init() {
-      self = .lowPriority
-    }
-
-    public init?(rawValue: Int) {
-      switch rawValue {
-      case 1: self = .lowPriority
-      case 2: self = .highPriority
-      default: return nil
-      }
-    }
-
-    public var rawValue: Int {
-      switch self {
-      case .lowPriority: return 1
-      case .highPriority: return 2
-      }
-    }
-
-  }
-
   public init() {}
 
-  fileprivate var _sender: ClientId? = nil
+  fileprivate var _sender: Proteus_ClientId? = nil
   fileprivate var _nativePush: Bool? = nil
   fileprivate var _blob: Data? = nil
-  fileprivate var _nativePriority: NewOtrMessage.Priority? = nil
+  fileprivate var _nativePriority: Proteus_Priority? = nil
   fileprivate var _transient: Bool? = nil
 }
 
-#if swift(>=4.2)
-
-extension NewOtrMessage.Priority: CaseIterable {
-  // Support synthesized by the compiler.
-}
-
-#endif  // swift(>=4.2)
-
-public struct OtrAssetMeta {
+public struct Proteus_QualifiedNewOtrMessage {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var sender: ClientId {
-    get {return _sender ?? ClientId()}
+  public var sender: Proteus_ClientId {
+    get {return _sender ?? Proteus_ClientId()}
     set {_sender = newValue}
   }
   /// Returns true if `sender` has been explicitly set.
@@ -249,7 +321,213 @@ public struct OtrAssetMeta {
   /// Clears the value of `sender`. Subsequent reads from it will return its default value.
   public mutating func clearSender() {self._sender = nil}
 
-  public var recipients: [UserEntry] = []
+  public var recipients: [Proteus_QualifiedUserEntry] = []
+
+  public var nativePush: Bool {
+    get {return _nativePush ?? true}
+    set {_nativePush = newValue}
+  }
+  /// Returns true if `nativePush` has been explicitly set.
+  public var hasNativePush: Bool {return self._nativePush != nil}
+  /// Clears the value of `nativePush`. Subsequent reads from it will return its default value.
+  public mutating func clearNativePush() {self._nativePush = nil}
+
+  public var blob: Data {
+    get {return _blob ?? Data()}
+    set {_blob = newValue}
+  }
+  /// Returns true if `blob` has been explicitly set.
+  public var hasBlob: Bool {return self._blob != nil}
+  /// Clears the value of `blob`. Subsequent reads from it will return its default value.
+  public mutating func clearBlob() {self._blob = nil}
+
+  public var nativePriority: Proteus_Priority {
+    get {return _nativePriority ?? .lowPriority}
+    set {_nativePriority = newValue}
+  }
+  /// Returns true if `nativePriority` has been explicitly set.
+  public var hasNativePriority: Bool {return self._nativePriority != nil}
+  /// Clears the value of `nativePriority`. Subsequent reads from it will return its default value.
+  public mutating func clearNativePriority() {self._nativePriority = nil}
+
+  public var transient: Bool {
+    get {return _transient ?? false}
+    set {_transient = newValue}
+  }
+  /// Returns true if `transient` has been explicitly set.
+  public var hasTransient: Bool {return self._transient != nil}
+  /// Clears the value of `transient`. Subsequent reads from it will return its default value.
+  public mutating func clearTransient() {self._transient = nil}
+
+  /// For more details please refer to backend swagger at
+  /// https://staging-nginz-https.zinfra.io/api/swagger-ui/
+  public var clientMismatchStrategy: Proteus_QualifiedNewOtrMessage.OneOf_ClientMismatchStrategy? = nil
+
+  public var reportAll: Proteus_ClientMismatchStrategy.ReportAll {
+    get {
+      if case .reportAll(let v)? = clientMismatchStrategy {return v}
+      return Proteus_ClientMismatchStrategy.ReportAll()
+    }
+    set {clientMismatchStrategy = .reportAll(newValue)}
+  }
+
+  public var ignoreAll: Proteus_ClientMismatchStrategy.IgnoreAll {
+    get {
+      if case .ignoreAll(let v)? = clientMismatchStrategy {return v}
+      return Proteus_ClientMismatchStrategy.IgnoreAll()
+    }
+    set {clientMismatchStrategy = .ignoreAll(newValue)}
+  }
+
+  public var reportOnly: Proteus_ClientMismatchStrategy.ReportOnly {
+    get {
+      if case .reportOnly(let v)? = clientMismatchStrategy {return v}
+      return Proteus_ClientMismatchStrategy.ReportOnly()
+    }
+    set {clientMismatchStrategy = .reportOnly(newValue)}
+  }
+
+  public var ignoreOnly: Proteus_ClientMismatchStrategy.IgnoreOnly {
+    get {
+      if case .ignoreOnly(let v)? = clientMismatchStrategy {return v}
+      return Proteus_ClientMismatchStrategy.IgnoreOnly()
+    }
+    set {clientMismatchStrategy = .ignoreOnly(newValue)}
+  }
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  /// For more details please refer to backend swagger at
+  /// https://staging-nginz-https.zinfra.io/api/swagger-ui/
+  public enum OneOf_ClientMismatchStrategy: Equatable {
+    case reportAll(Proteus_ClientMismatchStrategy.ReportAll)
+    case ignoreAll(Proteus_ClientMismatchStrategy.IgnoreAll)
+    case reportOnly(Proteus_ClientMismatchStrategy.ReportOnly)
+    case ignoreOnly(Proteus_ClientMismatchStrategy.IgnoreOnly)
+
+    fileprivate var isInitialized: Bool {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch self {
+      case .reportOnly: return {
+        guard case .reportOnly(let v) = self else { preconditionFailure() }
+        return v.isInitialized
+      }()
+      case .ignoreOnly: return {
+        guard case .ignoreOnly(let v) = self else { preconditionFailure() }
+        return v.isInitialized
+      }()
+      default: return true
+      }
+    }
+
+  #if !swift(>=4.1)
+    public static func ==(lhs: Proteus_QualifiedNewOtrMessage.OneOf_ClientMismatchStrategy, rhs: Proteus_QualifiedNewOtrMessage.OneOf_ClientMismatchStrategy) -> Bool {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch (lhs, rhs) {
+      case (.reportAll, .reportAll): return {
+        guard case .reportAll(let l) = lhs, case .reportAll(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.ignoreAll, .ignoreAll): return {
+        guard case .ignoreAll(let l) = lhs, case .ignoreAll(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.reportOnly, .reportOnly): return {
+        guard case .reportOnly(let l) = lhs, case .reportOnly(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      case (.ignoreOnly, .ignoreOnly): return {
+        guard case .ignoreOnly(let l) = lhs, case .ignoreOnly(let r) = rhs else { preconditionFailure() }
+        return l == r
+      }()
+      default: return false
+      }
+    }
+  #endif
+  }
+
+  public init() {}
+
+  fileprivate var _sender: Proteus_ClientId? = nil
+  fileprivate var _nativePush: Bool? = nil
+  fileprivate var _blob: Data? = nil
+  fileprivate var _nativePriority: Proteus_Priority? = nil
+  fileprivate var _transient: Bool? = nil
+}
+
+public struct Proteus_ClientMismatchStrategy {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public struct ReportAll {
+    // SwiftProtobuf.Message conformance is added in an extension below. See the
+    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+    // methods supported on all messages.
+
+    public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+    public init() {}
+  }
+
+  public struct IgnoreAll {
+    // SwiftProtobuf.Message conformance is added in an extension below. See the
+    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+    // methods supported on all messages.
+
+    public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+    public init() {}
+  }
+
+  public struct ReportOnly {
+    // SwiftProtobuf.Message conformance is added in an extension below. See the
+    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+    // methods supported on all messages.
+
+    public var userIds: [Proteus_QualifiedUserId] = []
+
+    public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+    public init() {}
+  }
+
+  public struct IgnoreOnly {
+    // SwiftProtobuf.Message conformance is added in an extension below. See the
+    // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+    // methods supported on all messages.
+
+    public var userIds: [Proteus_QualifiedUserId] = []
+
+    public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+    public init() {}
+  }
+
+  public init() {}
+}
+
+public struct Proteus_OtrAssetMeta {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var sender: Proteus_ClientId {
+    get {return _sender ?? Proteus_ClientId()}
+    set {_sender = newValue}
+  }
+  /// Returns true if `sender` has been explicitly set.
+  public var hasSender: Bool {return self._sender != nil}
+  /// Clears the value of `sender`. Subsequent reads from it will return its default value.
+  public mutating func clearSender() {self._sender = nil}
+
+  public var recipients: [Proteus_UserEntry] = []
 
   public var isInline: Bool {
     get {return _isInline ?? false}
@@ -273,15 +551,24 @@ public struct OtrAssetMeta {
 
   public init() {}
 
-  fileprivate var _sender: ClientId? = nil
+  fileprivate var _sender: Proteus_ClientId? = nil
   fileprivate var _isInline: Bool? = nil
   fileprivate var _nativePush: Bool? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
-extension UserId: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = "UserId"
+fileprivate let _protobuf_package = "proteus"
+
+extension Proteus_Priority: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "LOW_PRIORITY"),
+    2: .same(proto: "HIGH_PRIORITY"),
+  ]
+}
+
+extension Proteus_UserId: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".UserId"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "uuid"),
   ]
@@ -310,15 +597,59 @@ extension UserId: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBas
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: UserId, rhs: UserId) -> Bool {
+  public static func ==(lhs: Proteus_UserId, rhs: Proteus_UserId) -> Bool {
     if lhs._uuid != rhs._uuid {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension ClientId: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = "ClientId"
+extension Proteus_QualifiedUserId: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".QualifiedUserId"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "id"),
+    2: .same(proto: "domain"),
+  ]
+
+  public var isInitialized: Bool {
+    if self._id == nil {return false}
+    if self._domain == nil {return false}
+    return true
+  }
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self._id) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self._domain) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if let v = self._id {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if let v = self._domain {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Proteus_QualifiedUserId, rhs: Proteus_QualifiedUserId) -> Bool {
+    if lhs._id != rhs._id {return false}
+    if lhs._domain != rhs._domain {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Proteus_ClientId: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ClientId"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "client"),
   ]
@@ -347,15 +678,15 @@ extension ClientId: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationB
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: ClientId, rhs: ClientId) -> Bool {
+  public static func ==(lhs: Proteus_ClientId, rhs: Proteus_ClientId) -> Bool {
     if lhs._client != rhs._client {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension ClientEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = "ClientEntry"
+extension Proteus_ClientEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ClientEntry"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "client"),
     2: .same(proto: "text"),
@@ -391,7 +722,7 @@ extension ClientEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementati
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: ClientEntry, rhs: ClientEntry) -> Bool {
+  public static func ==(lhs: Proteus_ClientEntry, rhs: Proteus_ClientEntry) -> Bool {
     if lhs._client != rhs._client {return false}
     if lhs._text != rhs._text {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
@@ -399,8 +730,8 @@ extension ClientEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementati
   }
 }
 
-extension UserEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = "UserEntry"
+extension Proteus_UserEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".UserEntry"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "user"),
     2: .same(proto: "clients"),
@@ -436,7 +767,7 @@ extension UserEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementation
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: UserEntry, rhs: UserEntry) -> Bool {
+  public static func ==(lhs: Proteus_UserEntry, rhs: Proteus_UserEntry) -> Bool {
     if lhs._user != rhs._user {return false}
     if lhs.clients != rhs.clients {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
@@ -444,8 +775,52 @@ extension UserEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementation
   }
 }
 
-extension NewOtrMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = "NewOtrMessage"
+extension Proteus_QualifiedUserEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".QualifiedUserEntry"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "domain"),
+    2: .same(proto: "entries"),
+  ]
+
+  public var isInitialized: Bool {
+    if self._domain == nil {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.entries) {return false}
+    return true
+  }
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self._domain) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.entries) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if let v = self._domain {
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    }
+    if !self.entries.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.entries, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Proteus_QualifiedUserEntry, rhs: Proteus_QualifiedUserEntry) -> Bool {
+    if lhs._domain != rhs._domain {return false}
+    if lhs.entries != rhs.entries {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Proteus_NewOtrMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".NewOtrMessage"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "sender"),
     2: .same(proto: "recipients"),
@@ -507,7 +882,7 @@ extension NewOtrMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: NewOtrMessage, rhs: NewOtrMessage) -> Bool {
+  public static func ==(lhs: Proteus_NewOtrMessage, rhs: Proteus_NewOtrMessage) -> Bool {
     if lhs._sender != rhs._sender {return false}
     if lhs.recipients != rhs.recipients {return false}
     if lhs._nativePush != rhs._nativePush {return false}
@@ -520,15 +895,272 @@ extension NewOtrMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementa
   }
 }
 
-extension NewOtrMessage.Priority: SwiftProtobuf._ProtoNameProviding {
+extension Proteus_QualifiedNewOtrMessage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".QualifiedNewOtrMessage"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "LOW_PRIORITY"),
-    2: .same(proto: "HIGH_PRIORITY"),
+    1: .same(proto: "sender"),
+    2: .same(proto: "recipients"),
+    3: .standard(proto: "native_push"),
+    4: .same(proto: "blob"),
+    5: .standard(proto: "native_priority"),
+    6: .same(proto: "transient"),
+    7: .standard(proto: "report_all"),
+    8: .standard(proto: "ignore_all"),
+    9: .standard(proto: "report_only"),
+    10: .standard(proto: "ignore_only"),
   ]
+
+  public var isInitialized: Bool {
+    if self._sender == nil {return false}
+    if let v = self._sender, !v.isInitialized {return false}
+    if !SwiftProtobuf.Internal.areAllInitialized(self.recipients) {return false}
+    if let v = self.clientMismatchStrategy, !v.isInitialized {return false}
+    return true
+  }
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._sender) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.recipients) }()
+      case 3: try { try decoder.decodeSingularBoolField(value: &self._nativePush) }()
+      case 4: try { try decoder.decodeSingularBytesField(value: &self._blob) }()
+      case 5: try { try decoder.decodeSingularEnumField(value: &self._nativePriority) }()
+      case 6: try { try decoder.decodeSingularBoolField(value: &self._transient) }()
+      case 7: try {
+        var v: Proteus_ClientMismatchStrategy.ReportAll?
+        if let current = self.clientMismatchStrategy {
+          try decoder.handleConflictingOneOf()
+          if case .reportAll(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.clientMismatchStrategy = .reportAll(v)}
+      }()
+      case 8: try {
+        var v: Proteus_ClientMismatchStrategy.IgnoreAll?
+        if let current = self.clientMismatchStrategy {
+          try decoder.handleConflictingOneOf()
+          if case .ignoreAll(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.clientMismatchStrategy = .ignoreAll(v)}
+      }()
+      case 9: try {
+        var v: Proteus_ClientMismatchStrategy.ReportOnly?
+        if let current = self.clientMismatchStrategy {
+          try decoder.handleConflictingOneOf()
+          if case .reportOnly(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.clientMismatchStrategy = .reportOnly(v)}
+      }()
+      case 10: try {
+        var v: Proteus_ClientMismatchStrategy.IgnoreOnly?
+        if let current = self.clientMismatchStrategy {
+          try decoder.handleConflictingOneOf()
+          if case .ignoreOnly(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {self.clientMismatchStrategy = .ignoreOnly(v)}
+      }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if let v = self._sender {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    }
+    if !self.recipients.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.recipients, fieldNumber: 2)
+    }
+    if let v = self._nativePush {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 3)
+    }
+    if let v = self._blob {
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 4)
+    }
+    if let v = self._nativePriority {
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+    }
+    if let v = self._transient {
+      try visitor.visitSingularBoolField(value: v, fieldNumber: 6)
+    }
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every case branch when no optimizations are
+    // enabled. https://github.com/apple/swift-protobuf/issues/1034
+    switch self.clientMismatchStrategy {
+    case .reportAll?: try {
+      guard case .reportAll(let v)? = self.clientMismatchStrategy else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+    }()
+    case .ignoreAll?: try {
+      guard case .ignoreAll(let v)? = self.clientMismatchStrategy else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+    }()
+    case .reportOnly?: try {
+      guard case .reportOnly(let v)? = self.clientMismatchStrategy else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+    }()
+    case .ignoreOnly?: try {
+      guard case .ignoreOnly(let v)? = self.clientMismatchStrategy else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+    }()
+    case nil: break
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Proteus_QualifiedNewOtrMessage, rhs: Proteus_QualifiedNewOtrMessage) -> Bool {
+    if lhs._sender != rhs._sender {return false}
+    if lhs.recipients != rhs.recipients {return false}
+    if lhs._nativePush != rhs._nativePush {return false}
+    if lhs._blob != rhs._blob {return false}
+    if lhs._nativePriority != rhs._nativePriority {return false}
+    if lhs._transient != rhs._transient {return false}
+    if lhs.clientMismatchStrategy != rhs.clientMismatchStrategy {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
 }
 
-extension OtrAssetMeta: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = "OtrAssetMeta"
+extension Proteus_ClientMismatchStrategy: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".ClientMismatchStrategy"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let _ = try decoder.nextFieldNumber() {
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Proteus_ClientMismatchStrategy, rhs: Proteus_ClientMismatchStrategy) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Proteus_ClientMismatchStrategy.ReportAll: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = Proteus_ClientMismatchStrategy.protoMessageName + ".ReportAll"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let _ = try decoder.nextFieldNumber() {
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Proteus_ClientMismatchStrategy.ReportAll, rhs: Proteus_ClientMismatchStrategy.ReportAll) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Proteus_ClientMismatchStrategy.IgnoreAll: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = Proteus_ClientMismatchStrategy.protoMessageName + ".IgnoreAll"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let _ = try decoder.nextFieldNumber() {
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Proteus_ClientMismatchStrategy.IgnoreAll, rhs: Proteus_ClientMismatchStrategy.IgnoreAll) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Proteus_ClientMismatchStrategy.ReportOnly: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = Proteus_ClientMismatchStrategy.protoMessageName + ".ReportOnly"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "user_ids"),
+  ]
+
+  public var isInitialized: Bool {
+    if !SwiftProtobuf.Internal.areAllInitialized(self.userIds) {return false}
+    return true
+  }
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.userIds) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.userIds.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.userIds, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Proteus_ClientMismatchStrategy.ReportOnly, rhs: Proteus_ClientMismatchStrategy.ReportOnly) -> Bool {
+    if lhs.userIds != rhs.userIds {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Proteus_ClientMismatchStrategy.IgnoreOnly: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = Proteus_ClientMismatchStrategy.protoMessageName + ".IgnoreOnly"
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .standard(proto: "user_ids"),
+  ]
+
+  public var isInitialized: Bool {
+    if !SwiftProtobuf.Internal.areAllInitialized(self.userIds) {return false}
+    return true
+  }
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.userIds) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.userIds.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.userIds, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Proteus_ClientMismatchStrategy.IgnoreOnly, rhs: Proteus_ClientMismatchStrategy.IgnoreOnly) -> Bool {
+    if lhs.userIds != rhs.userIds {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Proteus_OtrAssetMeta: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".OtrAssetMeta"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "sender"),
     2: .same(proto: "recipients"),
@@ -574,7 +1206,7 @@ extension OtrAssetMeta: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: OtrAssetMeta, rhs: OtrAssetMeta) -> Bool {
+  public static func ==(lhs: Proteus_OtrAssetMeta, rhs: Proteus_OtrAssetMeta) -> Bool {
     if lhs._sender != rhs._sender {return false}
     if lhs.recipients != rhs.recipients {return false}
     if lhs._isInline != rhs._isInline {return false}

--- a/Scripts/compile-swift-protos.sh
+++ b/Scripts/compile-swift-protos.sh
@@ -5,13 +5,12 @@ set -e
 BASE_FOLDER=`pwd`
 CARTHAGE=`Scripts/find-carthage.py`
 MESSAGES_PROTO_DIR="${CARTHAGE}/Checkouts/generic-message-proto/proto"
-OTR_PROTO_DIR="${CARTHAGE}/Checkouts/backend-api-protobuf/proto"
 
 echo "Found carthage folder in ${CARTHAGE}"
 
 # 2) Compile Protos
 function compile_proto() {
-protoc "$1/$2" \
+protoc "$2" \
     --proto_path="$1" \
     --swift_out="${BASE_FOLDER}/Protos/" \
     --swift_opt=FileNaming=DropPath \
@@ -19,7 +18,7 @@ protoc "$1/$2" \
 }
 
 compile_proto $MESSAGES_PROTO_DIR "messages.proto"
-compile_proto $OTR_PROTO_DIR "otr.proto"
+compile_proto $MESSAGES_PROTO_DIR "otr.proto"
 
 # 3) Insert Wire Header
 cd Protos

--- a/Scripts/find-carthage.py
+++ b/Scripts/find-carthage.py
@@ -24,9 +24,9 @@ if __name__ == "__main__":
     cwd = os.path.normpath(os.getcwd())
     paths = [find_in_path(cwd), find_in_subfolder(cwd)]
     for found_path in [x for x in paths if x != None]:
-        print found_path,
+        print(found_path)
         sys.exit(0)
-
-    print >> sys.stderr, "No Carthage folder found"
+    
+    print("No Carthage folder found", file=sys.stderr)
     sys.exit(1)
     

--- a/WireProtos.xcodeproj/project.pbxproj
+++ b/WireProtos.xcodeproj/project.pbxproj
@@ -50,7 +50,7 @@
 		090838241B87347900629095 /* messages.proto */ = {isa = PBXFileReference; lastKnownFileType = text; name = messages.proto; path = "Carthage/Checkouts/generic-message-proto/proto/messages.proto"; sourceTree = SOURCE_ROOT; };
 		099223A01BECF63800668091 /* Cartfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		099223A11BECF65A00668091 /* Cartfile.private */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.private; sourceTree = "<group>"; };
-		099223A61BED06E400668091 /* otr.proto */ = {isa = PBXFileReference; lastKnownFileType = text; name = otr.proto; path = "Carthage/Checkouts/backend-api-protobuf/proto/otr.proto"; sourceTree = SOURCE_ROOT; };
+		099223A61BED06E400668091 /* otr.proto */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.protobuf; name = otr.proto; path = "Carthage/Checkouts/generic-message-proto/proto/otr.proto"; sourceTree = SOURCE_ROOT; };
 		09B70B4D1B874390002667A6 /* version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = version.xcconfig; sourceTree = "<group>"; };
 		09B70B601B874390002667A6 /* WireProtos.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WireProtos.xcconfig; sourceTree = "<group>"; };
 		09BCDB6D1BCBE08D0020DCC7 /* medium.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = medium.jpg; sourceTree = "<group>"; };


### PR DESCRIPTION
## What's new in this PR?

Update protobuf version to v1.35.0 which include federation support.

## Note

I've updated the scripts to reflect the fact that `otr.proto` moved to the `wireapp/generic-message-proto` repo and that python 3 is now the default python version on Mac.