### PR TITLE
chore: clean up arch related flags

### DIFF
--- a/Resources/Configurations/zmc-config/ios.xcconfig
+++ b/Resources/Configurations/zmc-config/ios.xcconfig
@@ -25,13 +25,12 @@
 
 // Architectures
 //
-VALID_ARCHS[sdk=iphoneos*] = arm64 armv7
-VALID_ARCHS[sdk=iphonesimulator*] = x86_64 arm64
+ARCHS[sdk=iphonesimulator*] = x86_64 arm64
 
 
 // Deployment
 //
-IPHONEOS_DEPLOYMENT_TARGET = 10.0
+IPHONEOS_DEPLOYMENT_TARGET = 12.1
 TARGETED_DEVICE_FAMILY = 1,2
 DYLIB_INSTALL_NAME_BASE = @rpath
 FRAMEWORK_VERSION = A


### PR DESCRIPTION
clean up deprecated  `VALID_ARCHS`
add `ARCHS[sdk=iphonesimulator*] = x86_64 arm64`
